### PR TITLE
Declare non-ASCII encoding in __init__.py

### DIFF
--- a/kdtree/__init__.py
+++ b/kdtree/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: latin-1 -*-
+
 """A Python implemntation of a kd-tree
 
 This package provides a simple implementation of a kd-tree in Python.


### PR DESCRIPTION
A very small change re: the below error:

```
Python 2.7.3 (default, Apr 20 2012, 22:39:59) 
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import kdtree
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ben/.virtualenvs/memorable/src/kdtree/kdtree/__init__.py", line 7
SyntaxError: Non-ASCII character '\xc3' in file /home/ben/.virtualenvs/memorable/src/kdtree/kdtree/__init__.py on line 7, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

thanks for the very clearly-written implementation!  Going to be using it on a very small dataset soon.
