### PR TITLE
fix search_knn issue

### DIFF
--- a/kdtree.py
+++ b/kdtree.py
@@ -468,7 +468,7 @@ class KDNode(Node):
             bestDist = float('inf')
 
         else:
-            bestNode, bestDist = sorted(results.items(), key=lambda n_d: n_d[1])[0]
+            bestNode, bestDist = sorted(results.items(), key=lambda n_d: n_d[1], reverse=True)[0]
 
         # If the current node is closer than the current best, then it
         # becomes the current best.
@@ -488,7 +488,7 @@ class KDNode(Node):
             results[self] = nodeDist
 
         # get new best
-        bestNode = next(iter(sorted(results, key=get_dist)))
+        bestNode = next(iter(sorted(results, key=get_dist, reverse=True)))
         bestDist = get_dist(bestNode)
 
         # Check whether there could be any points on the other side of the

--- a/test.py
+++ b/test.py
@@ -158,6 +158,30 @@ class BalanceTests(unittest.TestCase):
 
 class NearestNeighbor(unittest.TestCase):
 
+    def test_search_knn(self):
+        points = [(50, 20), (51, 19), (1, 80)]
+        tree = kdtree.create(points)
+        point = (48, 18)
+
+        all_dist = []
+        for p in tree.inorder():
+            dist = p.dist(point)
+            all_dist.append([p, dist])
+
+        all_dist = sorted(all_dist, key = lambda n:n[1])
+
+        result = tree.search_knn(point, 1)
+        self.assertEqual(result[0][1], all_dist[0][1])
+
+        result = tree.search_knn(point, 2)
+        self.assertEqual(result[0][1], all_dist[0][1])
+        self.assertEqual(result[1][1], all_dist[1][1])
+
+        result = tree.search_knn(point, 3)
+        self.assertEqual(result[0][1], all_dist[0][1])
+        self.assertEqual(result[1][1], all_dist[1][1])
+        self.assertEqual(result[2][1], all_dist[2][1])
+
     def test_search_nn(self, nodes=100):
         points = list(islice(random_points(), 0, nodes))
         tree = kdtree.create(points)


### PR DESCRIPTION
The search_knn function does not return k nearest neighbors,
when we go up the tree, we need compare bestDist with another child-tree and decide search or not more better neighbors in that child-tree.

But, your current implementation,  calculate bestDist by nearest point in result array, I think we should calculate it by most far point in result array.

In current implementation, only nearest point will be replaced with more good found, but the 2nd nearest or K-th nearest will not be replaced with more good found.
 
I will use a simple data to example this issue:

```
# three points in 2D
points = [(50, 20), (51, 19), (1, 80)]
tree = kdtree.create(points)
point = (48, 18)

kdtree.visualize(tree)

#            (50, 20) -A
#
#      (1, 80)-C    (51, 19) -B
# we mark them with label A, B, C, and D = (48, 18)

all_dist = []
for p in tree.inorder():
    dist = p.dist(point)
    all_dist.append([p, dist])

all_dist = sorted(all_dist, key = lambda n:n[1])

# we could know that:
# distance(A, D) = 8
# distance(B, D) = 10
# distance(C, D) = 6053

def print_node(a):
    print "--------------------------"
    for node, d in a:
        print node.data, d

print_node(tree.search_knn(point, 1))
# should got point A

print_node(tree.search_knn(point, 2))
# should got point A, B, but we got A, C

print_node(tree.search_knn(point, 3))
# should got point A, B, C
```

