### PR TITLE
Modify method 'add' to return newly added node. This can be used to add ...

### DIFF
--- a/kdtree.py
+++ b/kdtree.py
@@ -242,20 +242,20 @@ class KDNode(Node):
             # Adding has hit an empty leaf-node, add here
             if current.data is None:
                 current.data = point
-                break
+                return current
 
             # split on self.axis, recurse either left or right
             if point[current.axis] < current.data[current.axis]:
                 if current.left is None:
                     current.left = current.create_subnode(point)
-                    break
+                    return current.left
                 else:
                     current = current.left
                     #self.left.add(point)
             else:
                 if current.right is None:
                     current.right = current.create_subnode(point)
-                    break
+                    return current.right
                 else:
                     current = current.right
 

--- a/test.py
+++ b/test.py
@@ -270,6 +270,20 @@ class PointTypeTests(unittest.TestCase):
         self.assertEqual(res, kdtree.KDNode( (2, 3, 4) ))
 
 
+class PayloadTests(unittest.TestCase):
+    """ test tree.add() with payload """
+
+    def test_payload(self, nodes=100, dimensions=3):
+        points = list(islice(random_points(dimensions=dimensions), 0, nodes))
+        tree = kdtree.create(dimensions=dimensions)
+
+        for i, p in enumerate(points):
+            tree.add(p).payload = i
+
+        for i, p in enumerate(points):
+            self.assertEqual(i, tree.search_nn(p)[0].payload)
+
+
 def random_tree(nodes=20, dimensions=3, minval=0, maxval=100):
     points = list(islice(random_points(), 0, nodes))
     tree = kdtree.create(points)


### PR DESCRIPTION
...a payload to the node, e.g. tree.add(point).payload = 42. The payload can then be retrieved, e.g. print tree.search_nn(query).payload.