### PR TITLE
Optimisations for knn search

### DIFF
--- a/kdtree.py
+++ b/kdtree.py
@@ -470,6 +470,8 @@ class KDNode(Node):
         else:
             bestNode, bestDist = sorted(results.items(), key=lambda n_d: n_d[1], reverse=True)[0]
 
+        nodesChanged = False
+
         # If the current node is closer than the current best, then it
         # becomes the current best.
         nodeDist = get_dist(self)
@@ -478,17 +480,23 @@ class KDNode(Node):
                results.pop(bestNode)
 
             results[self] = nodeDist
+            nodesChanged = True
 
         # if we're equal to the current best, add it, regardless of k
         elif nodeDist == bestDist:
             results[self] = nodeDist
+            nodesChanged = True
 
         # if we don't have k results yet, add it anyway
         elif len(results) < k:
             results[self] = nodeDist
+            nodesChanged = True
 
-        # get new best
-        bestNode, bestDist = next(iter(sorted(results.items(), key=lambda n: n[1], reverse=True)))
+        # get new best only if nodes have changed
+        if nodesChanged:
+            bestNode, bestDist = next(iter(
+                sorted(results.items(), key=lambda n: n[1], reverse=True)
+            ))
 
         # Check whether there could be any points on the other side of the
         # splitting plane that are closer to the search point than the current

--- a/kdtree.py
+++ b/kdtree.py
@@ -488,8 +488,7 @@ class KDNode(Node):
             results[self] = nodeDist
 
         # get new best
-        bestNode = next(iter(sorted(results, key=get_dist, reverse=True)))
-        bestDist = get_dist(bestNode)
+        bestNode, bestDist = next(iter(sorted(results.items(), key=lambda n: n[1], reverse=True)))
 
         # Check whether there could be any points on the other side of the
         # splitting plane that are closer to the search point than the current


### PR DESCRIPTION
Hi,

I've been using this KDTree implementation for a simple KNN classifier, and made a small optimisation to speed up the KNN search.

I noticed in KDNode._search_node(), you sort the nodes by distance, which you already calculate and store in the results dict. The first commit changes the sorting operation to use the already calculated values, rather than recalculating the point-point distance for each item.

I ran it with my data set for my classifier, which reads a file, performs 500 inserts and then 268 KNN searches, and got my total runtime down from 9.8s to 2.8s(!!!!!!)

The second commit avoids doing this sort altogether if no nodes have been added to the list, and uses the previous values of bestNode and bestDist, as the values will not have change. This optimisation is a lot smaller, but could be useful for some search edge cases. In my particular data set it shaved an extra .5s off my already reduced search time, bringing me down to 2.3s.

Hope this speeds up your implementation of whatever you use this for :)

Denbeigh