### PR TITLE
fix original list order

### DIFF
--- a/kdtree.py
+++ b/kdtree.py
@@ -219,7 +219,8 @@ class KDNode(Node):
         sel_axis(axis) is used when creating subnodes of the current node. It
         receives the axis of the parent node and returns the axis of the child
         node. """
-
+        if type(data) == 'list':
+            data = list(data)
         super(KDNode, self).__init__(data, left, right)
         self.axis = axis
         self.sel_axis = sel_axis


### PR DESCRIPTION
When I use `kdtree.create`

```python
import random
import kdtree

a = []
for i in range(1000):
  a.append([random.randint() for _ in range(100)])
b = list(a)
kdtree.create(a)
a == b # False
```

I think this method shouldn't change the order in original list.