### PR TITLE
Removes old test and coverage runners.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ python:
   - "pypy"
   - "pypy3"
 
-script: python test.py
+script: python setup.py test
 
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,5 @@ setup(name=PACKAGE,
         PACKAGE[0] + '/' + PACKAGE + '/' + \
         PACKAGE + '-' + VERSION + '.tar.gz',
       classifiers=CLASSIFIERS,
+      test_suite='test',
 )

--- a/test.py
+++ b/test.py
@@ -11,14 +11,6 @@ import collections
 from itertools import islice
 from bounded_priority_queue import BoundedPriorityQueue
 
-try:
-    import coverage
-    coverage.erase()
-    coverage.start()
-
-except ImportError:
-    coverage = None
-
 # import after starting coverage, to ensure that import-time code is covered
 import kdtree
 
@@ -366,19 +358,3 @@ def random_point(dimensions=3, minval=0, maxval=100):
 def random_points(dimensions=3, minval=0, maxval=100):
     while True:
         yield random_point(dimensions, minval, maxval)
-
-
-if __name__ == '__main__':
-
-    suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
-    suite.addTest(doctest.DocTestSuite(kdtree))
-    runner = unittest.TextTestRunner(verbosity=2)
-    result = runner.run(suite)
-
-    if not result.wasSuccessful():
-        sys.exit(1)
-
-    if coverage is not None:
-        coverage.stop()
-        coverage.report([kdtree])
-        coverage.erase()


### PR DESCRIPTION
These commands can be run from the command-line instead:

    python -m unittest

or

    coverage run --source=kdtree -m unittest
