### PR TITLE
Speed up search knn

### DIFF
--- a/kdtree.py
+++ b/kdtree.py
@@ -411,6 +411,9 @@ class KDNode(Node):
         The result is an ordered list of (node, distance) tuples.
         """
 
+        if k < 1:
+            raise ValueError("k must be greater than 0.")
+
         if dist is None:
             get_dist = lambda n: n.dist(point)
         else:
@@ -439,7 +442,7 @@ class KDNode(Node):
         # so, replace it.
         item = (-nodeDist, next(counter), self)
         if len(results) >= k:
-            if -nodeDist > min(results)[0]:
+            if -nodeDist > results[0][0]:
                 heapq.heapreplace(results, item)
         else:
             heapq.heappush(results, item)
@@ -460,7 +463,7 @@ class KDNode(Node):
 
         # Search the other side of the splitting plane if it may contain
         # points closer than the farthest point in the current results.
-        if plane_dist2 > min(results)[0] or len(results) < k:
+        if -plane_dist2 > results[0][0] or len(results) < k:
             if point[self.axis] < self.data[self.axis]:
                 if self.right is not None:
                     self.right._search_node(point, k, results, get_dist,

--- a/test.py
+++ b/test.py
@@ -313,3 +313,7 @@ def random_point(dimensions=3, minval=0, maxval=100):
 def random_points(dimensions=3, minval=0, maxval=100):
     while True:
         yield random_point(dimensions, minval, maxval)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What this PR does:
- Speed up `_search_node`
    + Since the `0th` element of a heap is the smallest one, we can use `heap[0]` directly instead of `min(heap)`.
    + In `_search_node`, when checking whether to search the other side of a plane, the original condition is always true.

- Add code to run test script